### PR TITLE
add functionality to train with weighted data points

### DIFF
--- a/tffm/core.py
+++ b/tffm/core.py
@@ -52,6 +52,8 @@ class TFFMCore():
     seed : int or None, default: None
         Random seed used at graph creating time
 
+    use_weights: bool, default: False
+        Indicates if the training data has corresponding weights
 
     Attributes
     ----------
@@ -94,7 +96,7 @@ class TFFMCore():
     """
     def __init__(self, order=2, rank=2, input_type='dense', loss_function=utils.loss_logistic, 
                 optimizer=tf.train.AdamOptimizer(learning_rate=0.01), reg=0, init_std=0.01, 
-                use_diag=False, reweight_reg=False, seed=None):
+                use_diag=False, reweight_reg=False, seed=None, use_weights=False):
         self.order = order
         self.rank = rank
         self.use_diag = use_diag
@@ -107,6 +109,7 @@ class TFFMCore():
         self.seed = seed
         self.n_features = None
         self.graph = None
+        self.use_weights=use_weights
 
     def set_num_features(self, n_features):
         self.n_features = n_features
@@ -135,6 +138,7 @@ class TFFMCore():
             # tf.sparse_reorder is not needed since scipy return COO in canonical order
             self.train_x = tf.SparseTensor(self.raw_indices, self.raw_values, self.raw_shape)
         self.train_y = tf.placeholder(tf.float32, shape=[None], name='Y')
+        self.train_s = tf.placeholder_with_default(input=tf.constant([1.0]), shape=[None], name='S')
 
     def pow_matmul(self, order, pow):
         if pow not in self.x_pow_cache:
@@ -193,7 +197,11 @@ class TFFMCore():
 
     def init_loss(self):
         with tf.name_scope('loss') as scope:
-            self.loss = self.loss_function(self.outputs, self.train_y)
+            if self.use_weights:
+                self.loss = self.loss_function(self.outputs, self.train_y, self.train_s)
+            else:
+                self.loss = self.loss_function(self.outputs, self.train_y)
+
             self.reduced_loss = tf.reduce_mean(self.loss)
             tf.summary.scalar('loss', self.reduced_loss)
 

--- a/tffm/models.py
+++ b/tffm/models.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from .core import TFFMCore
 from .base import TFFMBaseModel
-from .utils import loss_logistic, loss_mse, sigmoid
+from .utils import loss_logistic, loss_mse, loss_weighted_logistic, loss_weighted_mse, sigmoid
 
 
 
@@ -26,7 +26,12 @@ class TFFMClassifier(TFFMBaseModel):
 
     def __init__(self, **init_params):
         assert 'loss_function' not in init_params
-        init_params['loss_function'] = loss_logistic
+        use_weights = init_params.get('use_weights', False)
+        if use_weights:
+            init_params['loss_function'] = loss_weighted_logistic
+        else:
+            init_params['loss_function'] = loss_logistic
+    
         self.init_basemodel(**init_params)
 
     def preprocess_target(self, y_):
@@ -86,7 +91,12 @@ class TFFMRegressor(TFFMBaseModel):
 
     def __init__(self, **init_params):
         assert 'loss_function' not in init_params
-        init_params['loss_function'] = loss_mse
+        use_weights = init_params.get('use_weights', False)
+        if use_weights:
+            init_params['loss_function'] = loss_weighted_mse
+        else:
+            init_params['loss_function'] = loss_mse
+
         self.init_basemodel(**init_params)
 
     def preprocess_target(self, y_):

--- a/tffm/utils.py
+++ b/tffm/utils.py
@@ -208,3 +208,15 @@ def loss_logistic(outputs, y):
 def loss_mse(outputs, y):
     return tf.pow(y -  tf.transpose(outputs), 2, name='mse_loss')
 
+# Loss function with weights. To use must set parameter use_weights to True.
+# Should take 3 tf.Ops: outputs, targets and weights and should return tf.Op of loss
+
+def loss_weighted_logistic(outputs, y, s):
+    margins = -y * tf.transpose(outputs)
+    raw_loss = tf.log(tf.add(1.0, tf.exp(margins)))
+    raw_loss_weighted = tf.multiply(s, raw_loss)
+    return tf.minimum(raw_loss_weighted, 100, name='truncated_log_weighted_loss')
+
+def loss_weighted_mse(outputs, y, s):
+    raw_loss = tf.pow(y -  tf.transpose(outputs), 2)
+    return tf.multiply(s, raw_loss, name='mse_weighted_loss')


### PR DESCRIPTION
Enable training with weighted/scaled data points. The weight vector `s` is an optional parameter that holds the weight of each data point in `X`. `s` is either `None` or an `np.array` with shape `(n_samples,)`. If `s` is used then the loss function is either `loss_weighted_logistic` or `loss_weighted_mse`.

In order to use the weights then `use_weights=True` has to be set when initializing the `TFFMClassifier` or `TFFMRegressor`.
 
@geffy 
