### PR TITLE
fix: exception is not imported sklearn.exceptions.NotFittedError

### DIFF
--- a/tffm/base.py
+++ b/tffm/base.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 from .core import TFFMCore
+import sklearn
 from sklearn.base import BaseEstimator
 from abc import ABCMeta, abstractmethod
 import six

--- a/tffm/base.py
+++ b/tffm/base.py
@@ -282,9 +282,14 @@ class TFFMBaseModel(six.with_metaclass(ABCMeta, BaseEstimator)):
 
     def save_model(self, path):
         """Saves the entire model"""
+        self.save_state(path)
+
         ## Additional core attributes that are to be pickled!
         CORE_ATTRS = ['n_features']
-        self.save_state(path)
+
+        # remove loss_function if classifier
+        if self.__class__.__name__.rpartition('.')[2] == 'TFFMClassifier':
+            del self._init_params_copy['loss_function']
         pickle_params ={
             'init': self._init_params_copy,
             'core': {k:getattr(self.core, k) for k in CORE_ATTRS}
@@ -305,7 +310,7 @@ class TFFMBaseModel(six.with_metaclass(ABCMeta, BaseEstimator)):
             path: path to save pickled model file with extension .tffm
         """
         if klass.__name__.rpartition('.')[2] not in ['TFFMRegressor', 'TFFMClassifier']:
-            raise Exception('klass is not supported: %s'%klass)
+            raise TypeError('klass is not supported: %s'%klass)
         _unpickled_obj = pickle.load(open(path+'.tffm', 'rb'))
         _new_model = klass(**_unpickled_obj['init'])
         for k in _unpickled_obj['core']:

--- a/tffm/base.py
+++ b/tffm/base.py
@@ -289,6 +289,9 @@ class TFFMBaseModel(six.with_metaclass(ABCMeta, BaseEstimator)):
             'init': self._init_params_copy,
             'core': {k:getattr(self.core, k) for k in CORE_ATTRS}
         }
+        if not os.path.isdir(os.path.dirname(path)):
+            os.makedirs(path, exist_ok=True)
+
         pickle.dump(pickle_params, open(path+'.tffm', 'wb'))
 
     @staticmethod

--- a/tffm/models.py
+++ b/tffm/models.py
@@ -3,7 +3,7 @@
 import numpy as np
 from .base import TFFMBaseModel
 from .utils import loss_logistic, loss_mse,  sigmoid
-
+import copy
 
 
 class TFFMClassifier(TFFMBaseModel):
@@ -24,6 +24,7 @@ class TFFMClassifier(TFFMBaseModel):
         base class TFFMBaseModel."""
 
         init_params['loss_function'] = loss_logistic
+        self._init_params_copy = copy.deepcopy(init_params)
         self.init_basemodel(**init_params)
 
     def _preprocess_sample_weights(self, sample_weight, pos_class_weight, used_y):
@@ -118,6 +119,7 @@ class TFFMRegressor(TFFMBaseModel):
         not supported for TFFMRegressor. For custom loss function, extend the
         base class TFFMBaseModel."""
         
+        self._init_params_copy = copy.deepcopy(init_params)
         init_params['loss_function'] = loss_mse
         self.init_basemodel(**init_params)
 


### PR DESCRIPTION
Currently the error is "NameError: name 'sklearn' is not defined" which is not the intended one as sklearn is not in scope. So adding a import statement.

